### PR TITLE
Retrieve Contrast agent from Maven Central

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.3.3/apache-maven-3.3.3-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <version>1.5.4</version>
 
     <name>petclinic</name>
-    
+
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
@@ -24,7 +24,16 @@
         <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		
+
+        <!-- Contrast properties -->
+        <contrast.agent.version>3.7.5.15480</contrast.agent.version>
+        <contrast.agent.path>
+            ${project.build.directory}/dependency/contrast-agent-${contrast.agent.version}.jar
+        </contrast.agent.path>
+        <contrast.api.url>https://app.contrastsecurity.com/Contrast</contrast.api.url>
+        <contrast.api.key>${env.CONTRAST__API__KEY}</contrast.api.key>
+        <contrast.api.service_key>${env.CONTRAST__API__SERVICE_KEY}</contrast.api.service_key>
+        <contrast.api.user_name>${env.CONTRAST__API__USER_NAME}</contrast.api.user_name>
 
         <!-- Web dependencies -->
         <webjars-bootstrap.version>3.3.6</webjars-bootstrap.version>
@@ -131,12 +140,6 @@
         </dependency>
         <!-- end of webjars -->
 
-        <!-- Contrast Security -->
-        <dependency>
-            <groupId>com.contrastsecurity</groupId>
-            <artifactId>contrast-maven-plugin</artifactId>
-            <version>2.2</version>
-        </dependency>
 
         <!-- Girish: Integration test with selenium -->
         <dependency>
@@ -157,8 +160,8 @@
             <!-- <version>2.53.0</version> -->
         </dependency>
         <dependency>
-			<groupId>org.seleniumhq.selenium</groupId>  
-			<artifactId>htmlunit-driver</artifactId>  
+			<groupId>org.seleniumhq.selenium</groupId>
+			<artifactId>htmlunit-driver</artifactId>
 			<!-- <version>2.20</version> -->
 		</dependency>
         <dependency>
@@ -169,8 +172,7 @@
     </dependencies>
 
     <build>
-      <plugins>
-
+        <plugins>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
@@ -188,7 +190,7 @@
                 </executions>
             </plugin>
 
-            <!-- Spring Boot Actuator displays build-related information if a git.properties 
+            <!-- Spring Boot Actuator displays build-related information if a git.properties
                 file is present at the classpath -->
             <plugin>
                 <groupId>pl.project13.maven</groupId>
@@ -276,7 +278,7 @@
     		<artifactId>spring-boot-maven-plugin</artifactId>
     		<executions>
                     <execution>
-                        <!-- Spring Boot Actuator displays build-related information if a META-INF/build-info.properties 
+                        <!-- Spring Boot Actuator displays build-related information if a META-INF/build-info.properties
                             file is present -->
                         <goals>
                             <goal>build-info</goal>
@@ -303,13 +305,34 @@
       <build>
         <plugins>
             <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>retrieve-contrast-agent</id>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <phase>process-test-classes</phase>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.contrastsecurity</groupId>
+                                    <artifactId>contrast-agent</artifactId>
+                                    <version>${contrast.agent.version}</version>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
           <!--       Verify security and coverage during automated tests. -->
                 <configuration>
                     <argLine>
                         -javaagent:${project.basedir}/jacocoagent.jar=destfile=${project.basedir}/target/jacoco.exec
-                        -javaagent:${project.basedir}/contrast.jar
+                        -javaagent:${contrast.agent.path}
                         -Dcontrast.dir=${project.basedir}/working
                         -Dcontrast.log.daily=true
                         -Dcontrast.standalone.appname=petclinic
@@ -326,7 +349,7 @@
                 <configuration>
                     <!-- Verify security and coverage during normal use -->
                     <jvmArguments>
-                        -javaagent:${project.basedir}/contrast.jar
+                        -javaagent:${contrast.agent.path}
                         -Dcontrast.dir=${project.basedir}/working
                         -Dcontrast.log.daily=true
                         -Dcontrast.standalone.appname=petclinic
@@ -338,7 +361,7 @@
                 </configuration>
                 <executions>
                     <execution>
-                        <!-- Spring Boot Actuator displays build-related information if a META-INF/build-info.properties 
+                        <!-- Spring Boot Actuator displays build-related information if a META-INF/build-info.properties
                             file is present -->
                         <goals>
                             <goal>build-info</goal>
@@ -364,14 +387,8 @@
           <plugin>
 		       <groupId>com.contrastsecurity</groupId>
 		       <artifactId>contrast-maven-plugin</artifactId>
-		       <version>2.2</version>
+		       <version>2.6</version>
 		       <executions>
-		             <execution>
-		                 <id>install-contrast-jar</id>
-		                 <goals>
-		                     <goal>install</goal>
-		                 </goals>
-		             </execution>
 		             <execution>
 		                 <id>verify-with-contrast</id>
 		                 <phase>post-integration-test</phase>
@@ -381,14 +398,14 @@
 		             </execution>
 		       </executions>
 		       <configuration>
-			         <username>fixme</username>
-			         <apiKey>fixme</apiKey>
-			         <serviceKey>fixme</serviceKey>
-			         <apiUrl>http:fixme/Contrast/api</apiUrl>
-			         <orgUuid>fixme</orgUuid>
+			         <username>${contrast.api.user_name}</username>
+			         <apiKey>${contrast.api.key}</apiKey>
+			         <serviceKey>${contrast.api.service_key}</serviceKey>
+			         <apiUrl>${contrast.api.url}</apiUrl>
+			         <orgUuid>${contrast.organization_uuid}</orgUuid>
 			         <appName>petclinic</appName>
 			         <appVersion>petclinic-${build.number}</appVersion>
-			         <serverName>Maven.BuildServer.Local</serverName>
+			         <serverName>spring-petclinic-qa</serverName>
 			         <minSeverity>High</minSeverity>
 		        </configuration>
 	        </plugin>

--- a/readme.md
+++ b/readme.md
@@ -6,10 +6,17 @@ Vulnerable version of the venerable PetClinic
 <a href="https://speakerdeck.com/michaelisvy/spring-petclinic-sample-application">See the presentation here</a>
 
 ## Running petclinic locally
+
+Make sure you are using Java 1.8
+
+```shell script
+java -version
 ```
-	git clone https://github.com/spring-projects/spring-petclinic.git
-	cd spring-petclinic
-	./mvnw spring-boot:run
+
+```shell script
+git clone https://github.com/spring-projects/spring-petclinic.git
+cd spring-petclinic
+./mvnw spring-boot:run
 ```
 
 You can then access petclinic here: http://localhost:8080/


### PR DESCRIPTION
Retrieving the Contrast agent from Maven Central is preferable to retrieving the agent jar using the `contrast-maven-plugin`, because:

1. Maven will take care of caching the jar
2. Users can specify any version of the jar that we have available on Maven Central
3. It's more idiomatic for a Maven project

While I was here, I upgraded Maven and fixed issues related to that upgrade (Apache Commons dependency conflict in `AttackThread`). This should help users who have the latest Maven installed and choose to ignore the Maven wrapper.