### PR TITLE
:wrench: Replace deprecated legacy Contrast properties with new names

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -310,13 +310,12 @@
                     <argLine>
                         -javaagent:${project.basedir}/jacocoagent.jar=destfile=${project.basedir}/target/jacoco.exec
                         -javaagent:${project.basedir}/contrast.jar
-                        -Dcontrast.dir=${project.basedir}/working
-                        -Dcontrast.log.daily=true
-                        -Dcontrast.standalone.appname=petclinic
-                        -Dcontrast.override.appversion=petclinic-${build.number}
-                        -Dcontrast.server=spring-petclinic-qa
-                        -Dcontrast.env=qa
-                        -Dcsrf.protected.uris=csrf-urls.txt
+                        -Dcontrast.agent.contrast_working_dir=${project.basedir}/working
+                        -Dcontrast.agent.logger.roll_daily=true
+                        -Dcontrast.agent.java.standalone_app_name=${project.artifactId}
+                        -Dcontrast.application.version=petclinic-${build.number}
+                        -Dcontrast.server.name=spring-petclinic-qa
+                        -Dcontrast.server.environment=qa
                     </argLine>
                 </configuration>
             </plugin>
@@ -327,13 +326,12 @@
                     <!-- Verify security and coverage during normal use -->
                     <jvmArguments>
                         -javaagent:${project.basedir}/contrast.jar
-                        -Dcontrast.dir=${project.basedir}/working
-                        -Dcontrast.log.daily=true
-                        -Dcontrast.standalone.appname=petclinic
-                        -Dcontrast.override.appversion=petclinic-${build.number}
-                        -Dcontrast.server=spring-petclinic-dev
-                        -Dcontrast.env=development
-                        -Dcontrast.classpath.libs=true
+                        -Dcontrast.agent.contrast_working_dir=${project.basedir}/working
+                        -Dcontrast.agent.logger.roll_daily=true
+                        -Dcontrast.agent.java.standalone_app_name=${project.artifactId}
+                        -Dcontrast.application.version=petclinic-${build.number}
+                        -Dcontrast.server.name=spring-petclinic-dev
+                        -Dcontrast.server.environment=development
                     </jvmArguments>
                 </configuration>
                 <executions>


### PR DESCRIPTION
We don't want to encourage users to configure Contrast with deprecated property names.

Note: the Contrast agent jar's `properties` utility can help you find the replacements for a legacy property.

```shell
java -jar target/dependency/contrast-agent-3.7.5.15480.jar properties --filter=contrast.standalone.appname
*** Contrast Agent (version 3.7.5.15480)
CONFIG_PATH:

  Description: the path to the yml properties file, ie: /path/to/contrast_security.yml

  Environment Variable: CONTRAST_CONFIG_PATH
  System Property: -Dcontrast.config.path



STANDALONE_APPNAME:

  Description: Indicates the application is a standalone app with the provided name

  Default: None

  Yaml Path: agent.java.standalone_app_name
  Environment Variable: CONTRAST__AGENT__JAVA__STANDALONE_APP_NAME
  System Property: -Dcontrast.agent.java.standalone_app_name

  ⚠️  This configuration supports the following equivalent legacy configurations.
        System Properties: -Dcontrast.standalone.appname
```